### PR TITLE
Add acceleration (setAcc and .acc)

### DIFF
--- a/core/iioEngine.js
+++ b/core/iioEngine.js
@@ -1276,8 +1276,13 @@ var iio = {};
       ,ioObj = iio.ioObj;
 
    function update(dt){
-      if ((typeof this.vel != 'undefined' && this.vel.length() > 0) || (typeof this.torque != 'undefined' && this.torque > 0))
+      if ((typeof this.acc != 'undefined' && this.acc.length() > 0) || (typeof this.vel != 'undefined' && this.vel.length() > 0) || (typeof this.torque != 'undefined' && this.torque > 0))
          this.clearDraw();
+      if (typeof this.acc != 'undefined') {
+         if (typeof this.vel != 'undefined') this.vel = new ioVec(0, 0)
+         this.vel.x += this.acc.x;
+         this.vel.y += this.acc.y;
+      }
       if (typeof this.vel != 'undefined') this.translate(new ioVec(this.vel.x, this.vel.y));
       if (typeof this.torque != 'undefined'){
          this.rotation+=this.torque;
@@ -1329,6 +1334,7 @@ var iio = {};
       return true;
    }
    function setVel(v,y){this.vel = new ioVec(v,y);return this}
+   function setAcc(v,y){this.acc = new ioVec(v,y);return this}
    function setTorque(t){
       this.torque = t;
       if (typeof this.rotation == 'undefined')
@@ -1387,6 +1393,7 @@ var iio = {};
    function enableKinematics(){
       this.update=update;
       this.setVel=setVel;
+      this.setAcc=setAcc;
       this.setTorque=setTorque;
       this.setBounds=setBounds;
       this.setBound=setBound;


### PR DESCRIPTION
Added acceleration support for kinematics.

Example code:

```
var Example = function(io) {
    var dir = 1;

    var box = io.addObj(new iio.ioRect(500, 25, 10, 10)
        .setFillStyle('blue')
        .enableKinematics()
        .setAcc(0.1, 0)
        .setBound('right', 550, function(box) {
            if(dir == 1) {
                dir = -1;
                box.setAcc(-0.1, 0);
            }
            return true;
        })
        .setBound('left', 500, function(box) {
            if(dir == -1) {
                dir = 1;
                box.setAcc(0.1, 0);
            }
            return true;
        }));

    io.setFramerate(60);
};
iio.start(Example);
```
