### PR TITLE
Fix getCellAt behaviour with separate coordinates.

### DIFF
--- a/core/iioEngine.js
+++ b/core/iioEngine.js
@@ -1367,7 +1367,14 @@ var iio = {};
       }
    }
    Grid.prototype.getCellAt = function(pos,y){
-      var cell = new iio.Vec(Math.floor((pos.x-this.pos.x)/this.res.x), Math.floor((pos.y-this.pos.y)/this.res.y));
+      if(typeof(pos.x) != 'undefined') {
+         var pos2 = pos;
+      } else if(typeof(y) != 'undefined') {
+         var pos2 = new iio.Vec(pos,y);
+      } else {
+         return false;
+      }
+      var cell = new iio.Vec(Math.floor((pos2.x-this.pos.x)/this.res.x), Math.floor((pos2.y-this.pos.y)/this.res.y));
       if (cell.x >= 0 && cell.x < this.C && cell.y >=0 && cell.y < this.R)
          return cell;
       return false;


### PR DESCRIPTION
The documentation reads that getCellAt can be called with a Vec and two
coordinates. This makes the code match the doc.
